### PR TITLE
ensure getting snapshots from source pool only

### DIFF
--- a/scripts/zfs_backup
+++ b/scripts/zfs_backup
@@ -129,7 +129,7 @@ class Backup:
     def get_snapshots(self, dataset, use_tag):
         #print("Getting snapshots for " + dataset + " ...")
 
-        common_cmd = zfs_cmd + ' list -H -t snapshot -o name -s name | grep ' + dataset
+        common_cmd = zfs_cmd + ' list -H -t snapshot -o name -s name | grep -E "^' + dataset + '"'
 
         if use_tag == True and self.tag:
             cmd = common_cmd + ' | grep -E ' + self.tag + '$'


### PR DESCRIPTION
Brief: fixes an issues hindered by using typical pool names like backup and rpool where their natural ordering happens to place the backup datasets at the top of the list when calling get_snapshots

To reproduce:
- have backup pool name made of the source's name and suffixed by anything (such as "_bak")
- take an initial backup
- snashot again and attempt an incremental backup

For instance:
zfs_backup -b mypool_bak -d mypool/DAT/HOME/myuser -l TEST

yields:
mypool_bak/mypool/DAT/HOME/myuser

get_snapshots results in:
mypool/DAT/HOME/myuser@????-??-??-????-??-TEST
mypool_bak/mypool/DAT/HOME/myuser@????-??-??-????-??-TEST
